### PR TITLE
Create dialogue mod

### DIFF
--- a/mods/dialogue/LICENSE.txt
+++ b/mods/dialogue/LICENSE.txt
@@ -1,0 +1,11 @@
+License for Code
+----------------
+
+Copyright (C) 2016 rubenwardy <rubenwardy@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+http://www.gnu.org/licenses/lgpl-2.1.html

--- a/mods/dialogue/README.txt
+++ b/mods/dialogue/README.txt
@@ -1,0 +1,33 @@
+# Dialogue
+
+Formspec API to chat with NPCs
+
+```lua
+minetest.register_chatcommand("a", {
+	func = function(name, param)
+		local d = dialogue.new("Hi! I'm the blacksmith. How can I help you?")
+		d:add_option("What do you have for sale?", function(name)
+			print("ans: sale")
+		end)
+		d:add_option("Could you use any help?", function(name)
+			print("ans: ask for quests")
+		end)
+		d:add_option("Nevermind", function(name)
+			print("ans: nevermind")
+		end)
+		d:show(name)
+	end
+})
+```
+
+## Methods
+
+* `dialogue.new(question_text)` - returns dialogue builder (used below as `d` variable)
+	* `d:add_option(answer_text, callback_func)` - adds option to dialogue builder
+	* `d:show(player_name)` - show to player name using dialogue.ask
+	* `callback_func` - called like callback_func(name_of_player_shown_to)
+* `dialogue.ask(name, question, answers)`
+	* Shouldn't be used directly unless you need finer control.
+	* `name`: player to show formspec to
+	* `question`: text, what the NPC said
+	* `answer`: array of objects. `{ { text = "answer", callback = function(name) end } }`

--- a/mods/dialogue/init.lua
+++ b/mods/dialogue/init.lua
@@ -1,0 +1,64 @@
+dialogue = {
+	contexts = {}
+}
+
+function dialogue.ask(name, question, answers)
+	dialogue.contexts[name] = {
+		answers = answers
+	}
+
+	-- generate formspec and show
+	local arrays = {
+		"size[8,3]",
+		default.gui_colors,
+		default.gui_bg,
+		"label[0,0;",
+		question
+	}
+
+	for i = 1, #answers do
+		local ans = answers[i]
+		arrays[#arrays + 1] = "]button_exit[0,"
+		arrays[#arrays + 1] = i * 0.75
+		arrays[#arrays + 1] = ";8,1;btn_"
+		arrays[#arrays + 1] = i
+		arrays[#arrays + 1] = ";"
+		arrays[#arrays + 1] = ans.text
+	end
+	arrays[#arrays + 1] = "]"
+
+	minetest.show_formspec(name, "dialogue:ask", table.concat(arrays, ""))
+end
+
+function dialogue.new(question)
+	return {
+		_answers = {},
+		add_option = function(self, text, callback)
+			self._answers[#self._answers + 1] = {
+				text = text,
+				callback = callback
+			}
+		end,
+		show = function(self, name)
+			dialogue.ask(name, question, self._answers)
+		end
+	}
+end
+
+minetest.register_on_player_receive_fields(function(player, formname, fields)
+	if formname ~= "dialogue:ask" then
+		return
+	end
+
+	local context = dialogue.contexts[player:get_player_name()]
+	if context then
+		for i = 1, #context.answers do
+			if fields["btn_" .. i] then
+				local ans = context.answers[i]
+				if ans.callback then
+					ans.callback(player:get_player_name())
+				end
+			end
+		end
+	end
+end)


### PR DESCRIPTION
![screenshot_2016-07-23_01-19-00](https://cloud.githubusercontent.com/assets/2122943/17074535/3520718c-5074-11e6-9644-bab51ac6f537.png)

Adds a mod to provide an API to show chat dialogues.

Todo: only supports max 3 answers, need to be made scalable

```lua
minetest.register_chatcommand("a", {
	func = function(name, param)
		local d = dialogue.new("Hi! I'm the blacksmith. How can I help you?")
		d:add_option("What do you have for sale?", function(name)
			print("ans: sale")
		end)
		d:add_option("Could you use any help?", function(name)
			print("ans: ask for quests")
		end)
		d:add_option("Nevermind", function(name)
			print("ans: nevermind")
		end)
		d:show(name)
	end
})
```