### PR TITLE
implement rudimentary builder experience

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -513,6 +513,7 @@ minetest.register_node("default:glass", {
 	inventory_image = minetest.inventorycube("default_glass.png"),
 	paramtype = "light",
 	groups = {crumbly = 3},
+	builder_xp = 3,
 })
 
 -- wool

--- a/mods/xp/init.lua
+++ b/mods/xp/init.lua
@@ -207,9 +207,19 @@ function xp.miner_xp()
 	end)
 end
 
+function xp.builder_xp()
+	minetest.register_on_placenode(function(pos, newnode, placer)
+		local builder_xp = minetest.registered_nodes[newnode.name].builder_xp
+		if builder_xp then
+			xp.add_xp(placer, builder_xp)
+		end
+	end)
+end
+
 xp.miner_xp()
 xp.crafter_xp()
 xp.explorer_xp()
+xp.builder_xp()
 
 xp.load_xp()
 xp.load_levels()


### PR DESCRIPTION
Ready to merge
The last of the simple experience collectors, in this case i have added it only to the glass node, cause dig this node give nothing to the player (evade circularity).
We don't need to have an method to decide if a player build something of nice, but the action o place a node get to a player experience.