### PR TITLE
add utility mod container

### DIFF
--- a/mods/utility/LICENSE.txt
+++ b/mods/utility/LICENSE.txt
@@ -1,0 +1,25 @@
+License for Code
+----------------
+
+Copyright (C) 2017 pandaro (parando) <padarogames@gmail.com>
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+http://www.gnu.org/licenses/lgpl-2.1.html
+
+License for Media
+-----------------
+
+CC-BY-SA 3.0 UNPORTED. Created by pandaro (padarogames@gmail.com)

--- a/mods/utility/init.lua
+++ b/mods/utility/init.lua
@@ -1,0 +1,27 @@
+utility = {}
+
+utility.debugEnabled = false
+function utylity.debug(target)
+	if not utility.debugEnabled then return end
+	if type(target) == "string" then
+		print(tostring(target))
+	elseif type(target) == "number" then
+		print(tostring(target))
+	elseif type(target) == "table" then
+		for key, value in ipairs(target) do
+			print(tostring(key) .. tostring(' -> ') .. tostring(value))
+		end
+	elseif type(target) == "userdata" then
+		local _t = getmetatable(target)
+		print(_t)
+		for key, value in ipairs(_t) do
+			print(tostring(key) .. tostring(' -> ') .. tostring(value))
+		end
+	elseif type(target) == "nil" then
+		print(tostring(target))
+	elseif type(target) == "boolean" then
+		print(tostring(target))
+	else
+		print(tostring('cannot print "' .. tostring(type(target)) .. tostring("type")))
+	end
+end

--- a/mods/utility/init.lua
+++ b/mods/utility/init.lua
@@ -1,7 +1,7 @@
 utility = {}
 
 utility.debugEnabled = false
-function utylity.debug(target)
+function utility.debug(target)
 	if not utility.debugEnabled then return end
 	if type(target) == "string" then
 		print(tostring(target))

--- a/mods/utility/init.lua
+++ b/mods/utility/init.lua
@@ -2,26 +2,27 @@ utility = {}
 
 utility.debugEnabled = false
 function utility.debug(target)
-	if not utility.debugEnabled then return end
-	if type(target) == "string" then
-		print(tostring(target))
-	elseif type(target) == "number" then
-		print(tostring(target))
-	elseif type(target) == "table" then
-		for key, value in ipairs(target) do
-			print(tostring(key) .. tostring(' -> ') .. tostring(value))
+	if utility.debugEnabled or debug then
+		if type(target) == "string" then
+			print(tostring(target))
+		elseif type(target) == "number" then
+			print(tostring(target))
+		elseif type(target) == "table" then
+			for key, value in ipairs(target) do
+				print(tostring(key) .. tostring(' -> ') .. tostring(value))
+			end
+		elseif type(target) == "userdata" then
+			local _t = getmetatable(target)
+			print(_t)
+			for key, value in ipairs(_t) do
+				print(tostring(key) .. tostring(' -> ') .. tostring(value))
+			end
+		elseif type(target) == "nil" then
+			print(tostring(target))
+		elseif type(target) == "boolean" then
+			print(tostring(target))
+		else
+			print(tostring('cannot print "' .. tostring(type(target)) .. tostring("type")))
 		end
-	elseif type(target) == "userdata" then
-		local _t = getmetatable(target)
-		print(_t)
-		for key, value in ipairs(_t) do
-			print(tostring(key) .. tostring(' -> ') .. tostring(value))
-		end
-	elseif type(target) == "nil" then
-		print(tostring(target))
-	elseif type(target) == "boolean" then
-		print(tostring(target))
-	else
-		print(tostring('cannot print "' .. tostring(type(target)) .. tostring("type")))
 	end
 end


### PR DESCRIPTION
The scope of this mod is to be a container of useful common function.
The first function added is a debug function.
Just use utility.debug(target) instead print(something).
You can enable or disable the debug just setting the main variable `utility.debugEnable = true` or if you need you can  sub-set it locally in order to debug just a portion of code
